### PR TITLE
Correction of load condition in training.py

### DIFF
--- a/training.py
+++ b/training.py
@@ -109,7 +109,7 @@ def train_single_scale(params, signals_list, fs_list, generators_list, noise_amp
 
     reconstruction_noise = signal_padder(reconstruction_noise)
 
-    if scale_idx > 1:
+    if scale_idx >= 1:
         netG.load_state_dict(
             torch.load('%s/netGScale%d.pth' % (params.output_folder, scale_idx - 1), map_location=params.device))
         netD.load_state_dict(


### PR DESCRIPTION
Correction of the condition to load netG and netD in training_single_scale method:
   "if scale_idx >= 1"
Instead of:
    "if scale_idx > 1"
So that the models at scale 0 can be loaded for the scale 1

